### PR TITLE
feat: Allow use of existing MediaStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Type: `function`, Optional, Arguments: (1) video devices matching `facingMode`, 
 
 Called when choosing which device to use for scanning. By default chooses the first video device matching `facingMode`, if no devices match the first video device found is choosen.
 
+**initialStream**
+
+Type: `MediaStream`, Optional
+
+Existing MediaStream to use initially.
+
 ## Dev
 
 ### Install dependencies

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ class Reader extends Component {
     super(props)
 
     this.els = {}
+    this.initialStreamStarted = false;
     // Bind function to the class
     this.initiate = this.initiate.bind(this)
     this.initiateLegacyMode = this.initiateLegacyMode.bind(this)
@@ -106,20 +107,25 @@ class Reader extends Component {
   }
 
   initiate(props = this.props) {
-    const { onError, facingMode, chooseDeviceId } = props
+    const { onError, facingMode, chooseDeviceId, initialStream } = props
 
-    getDeviceId(facingMode, chooseDeviceId)
-      .then(deviceId => {
-        return navigator.mediaDevices.getUserMedia({
-          video: {
-            deviceId,
-            width: { min: 360, ideal: 1280, max: 1920 },
-            height: { min: 240, ideal: 720, max: 1080 },
-          },
+    if (initialStream && !this.initialStreamStarted) {
+      this.initialStreamStarted = true;
+      this.handleVideo(initialStream);
+    } else {
+      getDeviceId(facingMode, chooseDeviceId)
+        .then(deviceId => {
+          return navigator.mediaDevices.getUserMedia({
+            video: {
+              deviceId,
+              width: { min: 360, ideal: 1280, max: 1920 },
+              height: { min: 240, ideal: 720, max: 1080 },
+            },
+          })
         })
-      })
-      .then(this.handleVideo)
-      .catch(onError)
+        .then(this.handleVideo)
+        .catch(onError)
+    }
   }
 
   handleVideo(stream) {


### PR DESCRIPTION
Adds the ability to reuse an existing `MediaStream`.

By default Firefox prompts the user every time we _request_ camera access, even if we already have access to a stream. 

In my app I already have a `MediaStream` available so this small modification allows me to reuse that stream rather than creating a new one and asking the user for access again.