### PR TITLE
fix: Use filtered VideoDevicesArray to access the only available VideoDevice

### DIFF
--- a/lib/getDeviceId.js
+++ b/lib/getDeviceId.js
@@ -29,7 +29,7 @@ function getDeviceId(facingMode) {
         return;
       } else if (videoDevices.length == 1) {
         // Only 1 video device available thus stop here
-        resolve(devices[0].deviceId);
+        resolve(videoDevices[0].deviceId);
         return;
       }
 

--- a/src/getDeviceId.js
+++ b/src/getDeviceId.js
@@ -27,7 +27,7 @@ function getDeviceId(facingMode, chooseDeviceId = defaultDeviceIdChooser) {
         return
       } else if (videoDevices.length == 1) {
         // Only 1 video device available thus stop here
-        resolve(devices[0].deviceId)
+        resolve(videoDevices[0].deviceId)
         return
       }
 


### PR DESCRIPTION
If only one video device is available it uses the first item of the device array. If this is not the video device you get an Constraint Error for the given deviceId.

This fix returns the first entry of the already filtered and checked video device array to ensure that the only available video deviceId is used.